### PR TITLE
Add optional list of explicitly allowed terms

### DIFF
--- a/docs/rules/use-inclusive-words.md
+++ b/docs/rules/use-inclusive-words.md
@@ -47,6 +47,25 @@ This is an example for a custom words file. The `explanation` key is optional. I
 }
 ```
 
+You may also specify a list of explicitly allowed terms using the `allowedTerms` key. The list of terms should be the full word of the allowed term (not a part of a word) and should be all lowercase.
+
+```json
+{
+    "allowedTerms": ["mastercard"]
+}
+```
+
+This will allow all of the following to pass without warning or error:
+
+-   `mastercard`
+-   `MasterCard`
+-   `masterCard`
+-   `"The card type is MasterCard"`
+
+But it will fail on the following due to it not being the full word.
+
+-   `masterCardVerification`
+
 ## When not to use it
 
 If you don't want to check for inclusive language in your codebase.

--- a/lib/config/inclusive-words.json
+++ b/lib/config/inclusive-words.json
@@ -21,5 +21,5 @@
             "explanation": "Instead of '{{word}}', you really should consider an alternative like '{{suggestion}}'."
         }
     ],
-    "exclusionList": []
+    "allowedTerms": []
 }

--- a/lib/config/inclusive-words.json
+++ b/lib/config/inclusive-words.json
@@ -20,5 +20,6 @@
             "suggestion": "secondary",
             "explanation": "Instead of '{{word}}', you really should consider an alternative like '{{suggestion}}'."
         }
-    ]
+    ],
+    "exclusionList": []
 }

--- a/lib/rules/use-inclusive-words.js
+++ b/lib/rules/use-inclusive-words.js
@@ -34,7 +34,7 @@ function validateIfInclusive(context, node, value) {
         const matches = value.match(regex);
         if (matches) {
             return matches.filter(
-                (word) => !ruleConfig.exclusionList.includes(word.toLowerCase())
+                (word) => !ruleConfig.allowedTerms.includes(word.toLowerCase())
             ).length;
         }
         return null;
@@ -92,9 +92,9 @@ module.exports = {
             if (customConfig !== undefined) {
                 ruleConfig = {
                     words: [...ruleConfig.words, ...(customConfig.words || [])],
-                    exclusionList: [
-                        ...ruleConfig.exclusionList,
-                        ...(customConfig.exclusionList || [])
+                    allowedTerms: [
+                        ...ruleConfig.allowedTerms,
+                        ...(customConfig.allowedTerms || [])
                     ]
                 };
             }

--- a/lib/rules/use-inclusive-words.js
+++ b/lib/rules/use-inclusive-words.js
@@ -28,8 +28,16 @@ function validateIfInclusive(context, node, value) {
 
     let regex;
     const result = ruleConfig.words.filter((wordDeclaration) => {
-        regex = new RegExp(wordDeclaration.word, 'ig');
-        return value.match(regex);
+        // match whole words and partial words, at the end and beginning of sentences
+        regex = new RegExp(`\\S*${wordDeclaration.word}\\S*`, 'ig');
+
+        const matches = value.match(regex);
+        if (matches) {
+            return matches.filter(
+                (word) => !ruleConfig.exclusionList.includes(word.toLowerCase())
+            ).length;
+        }
+        return null;
     });
 
     if (!result || result.length == 0) return;
@@ -83,7 +91,11 @@ module.exports = {
             const customConfig = customRuleConfig(context.options[0]);
             if (customConfig !== undefined) {
                 ruleConfig = {
-                    words: [...ruleConfig.words, ...customConfig.words]
+                    words: [...ruleConfig.words, ...customConfig.words],
+                    exclusionList: [
+                        ...ruleConfig.exclusionList,
+                        ...(customConfig.exclusionList || [])
+                    ]
                 };
             }
         }

--- a/lib/rules/use-inclusive-words.js
+++ b/lib/rules/use-inclusive-words.js
@@ -91,7 +91,7 @@ module.exports = {
             const customConfig = customRuleConfig(context.options[0]);
             if (customConfig !== undefined) {
                 ruleConfig = {
-                    words: [...ruleConfig.words, ...customConfig.words],
+                    words: [...ruleConfig.words, ...(customConfig.words || [])],
                     exclusionList: [
                         ...ruleConfig.exclusionList,
                         ...(customConfig.exclusionList || [])

--- a/tests/lib/config/inclusive-words.json
+++ b/tests/lib/config/inclusive-words.json
@@ -5,5 +5,6 @@
             "suggestion": "people",
             "explanation": "Instead of '{{word}}', you can use '{{suggestion}}'."
         }
-    ]
+    ],
+    "exclusionList": ["masterboo", "foomaster", "bazmasterbar"]
 }

--- a/tests/lib/config/inclusive-words.json
+++ b/tests/lib/config/inclusive-words.json
@@ -6,5 +6,5 @@
             "explanation": "Instead of '{{word}}', you can use '{{suggestion}}'."
         }
     ],
-    "exclusionList": ["masterboo", "foomaster", "bazmasterbar"]
+    "allowedTerms": ["masterfoo", "foomaster", "bazmasterbar"]
 }

--- a/tests/lib/rules/use-inclusive-words.test.js
+++ b/tests/lib/rules/use-inclusive-words.test.js
@@ -12,7 +12,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester();
 
-console.debug(customConfig);
+console.log(customConfig);
 
 ruleTester.run('use-inclusive-words', rule, {
     valid: [
@@ -21,6 +21,18 @@ ruleTester.run('use-inclusive-words', rule, {
         },
         {
             code: 'var message = "This is a group of people."',
+            options: [customConfig]
+        },
+        {
+            code: 'var ccType = "MasterBoo"',
+            options: [customConfig]
+        },
+        {
+            code: 'var fooMaster = 1',
+            options: [customConfig]
+        },
+        {
+            code: 'var BazMasterBar = function () {}',
             options: [customConfig]
         }
     ],

--- a/tests/lib/rules/use-inclusive-words.test.js
+++ b/tests/lib/rules/use-inclusive-words.test.js
@@ -24,7 +24,7 @@ ruleTester.run('use-inclusive-words', rule, {
             options: [customConfig]
         },
         {
-            code: 'var ccType = "MasterBoo"',
+            code: 'var ccType = "MasterFoo"',
             options: [customConfig]
         },
         {


### PR DESCRIPTION
This allows consumers to specify lists of allowed words in their repository. This is useful, for example, when there are words that cannot be changed (like the name of a popular credit card brand) or which will take more time to change than is currently possible for the project maintainers/when the change is ongoing (for example, database column name changes). This will allow people to enable the rule in order to proactively prevent the introduction of new non-inclusive language into their codebases without forcing codebases to be perfectly clear of errors before enabling the rule.