### PR TITLE
feat: Allow partial matches of allowed terms

### DIFF
--- a/lib/rules/use-inclusive-words.js
+++ b/lib/rules/use-inclusive-words.js
@@ -2,6 +2,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const {
+    getCustomRuleConfig,
+    mergeRuleConfigs
+} = require('../utils/custom-rule-config');
 
 const DEFAULT_MESSAGE =
     "The usage of the non-inclusive word '{{word}}' is discouraged, use '{{suggestion}}' instead.";
@@ -15,12 +19,27 @@ let ruleConfig = JSON.parse(
     'utf8'
 );
 
-function customRuleConfig(filePath) {
-    const customPath = path.resolve(process.cwd(), filePath);
-    if (fs.existsSync(customPath)) {
-        return JSON.parse(fs.readFileSync(customPath), 'utf8');
-    }
-    return;
+/**
+ * Remove allowed terms from the list of words, checking
+ * for partial or complete matches based on each allowed
+ * term's configuration.
+ *
+ * @param {string[]} words The list of words to filter
+ * @returns {string[]} The list of words excluding any allowed terms
+ */
+function excludeAllowedTerms(words) {
+    return words.filter((word) => {
+        const isAllowedTerm = ruleConfig.allowedTerms.find(
+            ({ term, allowPartialMatches }) => {
+                if (!allowPartialMatches) {
+                    return word.toLowerCase() === term;
+                }
+                return word.toLowerCase().includes(term);
+            }
+        );
+
+        return !isAllowedTerm;
+    });
 }
 
 function validateIfInclusive(context, node, value) {
@@ -33,9 +52,7 @@ function validateIfInclusive(context, node, value) {
 
         const matches = value.match(regex);
         if (matches) {
-            return matches.filter(
-                (word) => !ruleConfig.allowedTerms.includes(word.toLowerCase())
-            ).length;
+            return excludeAllowedTerms(matches).length;
         }
         return null;
     });
@@ -87,18 +104,12 @@ module.exports = {
         type: 'suggestion'
     },
     create: function (context) {
-        if (context.options && context.options.length > 0) {
-            const customConfig = customRuleConfig(context.options[0]);
-            if (customConfig !== undefined) {
-                ruleConfig = {
-                    words: [...ruleConfig.words, ...(customConfig.words || [])],
-                    allowedTerms: [
-                        ...ruleConfig.allowedTerms,
-                        ...(customConfig.allowedTerms || [])
-                    ]
-                };
-            }
+        const customConfig = getCustomRuleConfig(context);
+
+        if (customConfig) {
+            ruleConfig = mergeRuleConfigs(ruleConfig, customConfig);
         }
+
         return {
             Literal(node) {
                 validateIfInclusive(context, node, node.value);

--- a/lib/rules/use-inclusive-words.js
+++ b/lib/rules/use-inclusive-words.js
@@ -48,7 +48,7 @@ function validateIfInclusive(context, node, value) {
     let regex;
     const result = ruleConfig.words.filter((wordDeclaration) => {
         // match whole words and partial words, at the end and beginning of sentences
-        regex = new RegExp(`\\S*${wordDeclaration.word}\\S*`, 'ig');
+        regex = new RegExp(`[\\w-_]*${wordDeclaration.word}[\\w-_]*`, 'ig');
 
         const matches = value.match(regex);
         if (matches) {

--- a/lib/utils/custom-rule-config.js
+++ b/lib/utils/custom-rule-config.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+
+function getCustomRuleConfigFromPath(filePath) {
+    const customPath = path.resolve(process.cwd(), filePath);
+    if (fs.existsSync(customPath)) {
+        return JSON.parse(fs.readFileSync(customPath), 'utf8');
+    }
+    return;
+}
+
+/**
+ * Get the custom rule config if any.
+ *
+ * @param {object} context The ESLint context
+ * @returns {object|null} The resolved custom rule config or null if none exists.
+ */
+exports.getCustomRuleConfig = function getCustomRuleConfig(context) {
+    if (!context.options || context.options.length === 0) {
+        // no custom configuration path was given
+        return null;
+    }
+
+    const customConfig = getCustomRuleConfigFromPath(context.options[0]);
+
+    // massage allowedTerms for backwards compat
+    const allowedTerms = (customConfig.allowedTerms || []).map(
+        (allowedTerm) => {
+            switch (typeof allowedTerm) {
+                case 'string': {
+                    // if it's a string, the correct default for backwards compat is to only match whole words
+                    // so `allowPartialMatches` must default to false
+                    return { term: allowedTerm, allowPartialMatch: false };
+                }
+                case 'object': {
+                    // if it's already an object, just return it
+                    return allowedTerm;
+                }
+                default: {
+                    throw new Error(
+                        `'allowedTerms' must be an array of strings or objects. Received '${typeof allowedTerm}'`
+                    );
+                }
+            }
+        }
+    );
+
+    return {
+        // give everything safe defaults
+        words: customConfig.words || [],
+        allowedTerms: allowedTerms
+    };
+};
+
+/**
+ * Merge the default and custom configuration.
+ *
+ * @param {object} defaultConfig The default configuration
+ * @param {object} customConfig The custom configuration to merge into the default
+ */
+exports.mergeRuleConfigs = function mergeRuleConfigs(
+    defaultConfig,
+    customConfig
+) {
+    return {
+        words: [...defaultConfig.words, ...customConfig.words],
+        allowedTerms: [
+            ...defaultConfig.allowedTerms,
+            ...customConfig.allowedTerms
+        ]
+    };
+};

--- a/tests/lib/config/inclusive-words.json
+++ b/tests/lib/config/inclusive-words.json
@@ -11,6 +11,7 @@
         "foomaster",
         "bazmasterbar",
         { "term": "definitiely-partial-guys", "allowPartialMatches": true },
-        { "term": "not-partial-guys", "allowPartialMatches": false }
+        { "term": "not-partial-guys", "allowPartialMatches": false },
+        { "term": "notslugpartialguys", "allowPartialMatches": true }
     ]
 }

--- a/tests/lib/config/inclusive-words.json
+++ b/tests/lib/config/inclusive-words.json
@@ -6,5 +6,11 @@
             "explanation": "Instead of '{{word}}', you can use '{{suggestion}}'."
         }
     ],
-    "allowedTerms": ["masterfoo", "foomaster", "bazmasterbar"]
+    "allowedTerms": [
+        "masterfoo",
+        "foomaster",
+        "bazmasterbar",
+        { "term": "definitiely-partial-guys", "allowPartialMatches": true },
+        { "term": "not-partial-guys", "allowPartialMatches": false }
+    ]
 }

--- a/tests/lib/rules/use-inclusive-words.test.js
+++ b/tests/lib/rules/use-inclusive-words.test.js
@@ -34,6 +34,16 @@ ruleTester.run('use-inclusive-words', rule, {
         {
             code: 'var BazMasterBar = function () {}',
             options: [customConfig]
+        },
+        {
+            code:
+                '/* This is an example of non-partial matching not-partial-guys */',
+            options: [customConfig]
+        },
+        {
+            code:
+                '/* This is an example of partial matching (extra-definitiely-partial-guys) */',
+            options: [customConfig]
         }
     ],
     invalid: [
@@ -91,6 +101,15 @@ ruleTester.run('use-inclusive-words', rule, {
             errors: [
                 {
                     message: "Instead of 'master', you can use 'primary'."
+                }
+            ]
+        },
+        {
+            code: 'var message = "made-it-partial-not-partial-guys"',
+            options: [customConfig],
+            errors: [
+                {
+                    message: "Instead of 'guys', you can use 'people'."
                 }
             ]
         }

--- a/tests/lib/rules/use-inclusive-words.test.js
+++ b/tests/lib/rules/use-inclusive-words.test.js
@@ -37,12 +37,16 @@ ruleTester.run('use-inclusive-words', rule, {
         },
         {
             code:
-                '/* This is an example of non-partial matching not-partial-guys */',
+                '/* This is an example of non-partial matching (not-partial-guys) */',
             options: [customConfig]
         },
         {
             code:
                 '/* This is an example of partial matching (extra-definitiely-partial-guys) */',
+            options: [customConfig]
+        },
+        {
+            code: 'var something_notslugpartialguys = 323',
             options: [customConfig]
         }
     ],
@@ -110,6 +114,14 @@ ruleTester.run('use-inclusive-words', rule, {
             errors: [
                 {
                     message: "Instead of 'guys', you can use 'people'."
+                }
+            ]
+        },
+        {
+            code: 'var classname = "master-bar"',
+            errors: [
+                {
+                    message: "Instead of 'master', you can use 'primary'."
                 }
             ]
         }


### PR DESCRIPTION
## Changes proposed

* Update the API of `allowedTerms` to be `string|{ term: string, allowPartialMatches: boolean }`
* Update rule logic to match partial terms when `allowPartialMatches` is true for an allowed term
* Update tests
* Fix a bug I found where the regex was matching parenthesis. See commit description for details and links to examples
* Refactor custom rule configuration parsing logic into a separate utils/custom-rule-config module
    * Just took a stab at an organization that made sense to me but happy to change it in any way if there are suggestions for how to make this better.

Fixes #6 