### PR TITLE
feat: support for multiple suggestions

### DIFF
--- a/docs/rules/use-inclusive-words.md
+++ b/docs/rules/use-inclusive-words.md
@@ -45,8 +45,8 @@ Example of using an inline configuration:
                 "words": [
                     {
                         "word": "guys",
-                        "suggestion": "people",
-                        "explanation": "The usage of the non-inclusive word '{{word}}' is discouraged, use '{{suggestion}}' instead."
+                        "suggestions": ["people"],
+                        "explanation": "The usage of the non-inclusive word '{{word}}' is discouraged, use '{{suggestions}}' instead."
                     }
                 ]
             }
@@ -55,15 +55,15 @@ Example of using an inline configuration:
 }
 ```
 
-This is an example for a custom configuration. The `explanation` key is optional. If not present the default message will be used. If you want to include at runtime the `word` or `suggestion` in your explanation, put them between double curly braces.
+This is an example for a custom configuration. The `explanation` key is optional. If not present the default message will be used. If you want to include at runtime the `word` or `suggestions` in your explanation, put them between double curly braces.
 
 ```json
 {
     "words": [
         {
             "word": "guys",
-            "suggestion": "people",
-            "explanation": "The usage of the non-inclusive word '{{word}}' is discouraged, use '{{suggestion}}' instead."
+            "suggestions": ["people"],
+            "explanation": "The usage of the non-inclusive word '{{word}}' is discouraged, use '{{suggestions}}' instead."
         }
     ]
 }

--- a/lib/config/inclusive-words.json
+++ b/lib/config/inclusive-words.json
@@ -2,23 +2,23 @@
     "words": [
         {
             "word": "blacklist",
-            "suggestion": "blocklist",
-            "explanation": "To convey the same idea, consider '{{suggestion}}' instead of '{{word}}'."
+            "suggestions": ["blocklist"],
+            "explanation": "To convey the same idea, consider '{{suggestions}}' instead of '{{word}}'."
         },
         {
             "word": "whitelist",
-            "suggestion": "allowlist",
-            "explanation": "To convey the same idea, consider '{{suggestion}}' instead of '{{word}}'."
+            "suggestions": ["allowlist"],
+            "explanation": "To convey the same idea, consider '{{suggestions}}' instead of '{{word}}'."
         },
         {
             "word": "master",
-            "suggestion": "primary",
-            "explanation": "Instead of '{{word}}', you can use '{{suggestion}}'."
+            "suggestions": ["primary"],
+            "explanation": "Instead of '{{word}}', you can use '{{suggestions}}'."
         },
         {
             "word": "slave",
-            "suggestion": "secondary",
-            "explanation": "Instead of '{{word}}', you really should consider an alternative like '{{suggestion}}'."
+            "suggestions": ["secondary"],
+            "explanation": "Instead of '{{word}}', you really should consider an alternative like '{{suggestions}}'."
         }
     ],
     "allowedTerms": []

--- a/lib/rules/use-inclusive-words.js
+++ b/lib/rules/use-inclusive-words.js
@@ -8,11 +8,11 @@ const {
 } = require('../utils/custom-rule-config');
 
 const DEFAULT_MESSAGE =
-    "The usage of the non-inclusive word '{{word}}' is discouraged, use '{{suggestion}}' instead.";
+    "The usage of the non-inclusive word '{{word}}' is discouraged, use '{{suggestions}}' instead.";
 const RULE_CATEGORY = 'Language';
 const RULE_DESCRIPTION = 'highlights where non-inclusive language is used';
 // eslint-disable-next-line no-unused-vars
-const SUGGESTION_MESSAGE = "Replace word '{{word}}'' with '{{suggestion}}.'"; // Currently not in use
+const SUGGESTION_MESSAGE = "Replace word '{{word}}'' with '{{suggestions}}.'"; // Currently not in use
 
 let ruleConfig = JSON.parse(
     fs.readFileSync(path.resolve(__dirname, '../config/inclusive-words.json')),
@@ -61,7 +61,7 @@ function validateIfInclusive(context, node, value) {
 
     const data = {
         word: result[0].word,
-        suggestion: result[0].suggestion
+        suggestions: result[0].suggestions.join(', ')
     };
 
     const reportObject = {
@@ -72,13 +72,13 @@ function validateIfInclusive(context, node, value) {
         data
         // TODO: For now I am sticking with not providing autocorrect-suggestions, as there can be many variations
         // of how and where a word can show up.
-        // suggest: result[0].suggestion
+        // suggest: result[0].suggestions.join(', ')
         //     ? [
         //           {
         //               message: SUGGESTION_MESSAGE,
         //               data,
         //               fix: function (fixer) {
-        //                   return fixer.replaceText(node, value.replace(regex, result[0].suggestion));
+        //                   return fixer.replaceText(node, value.replace(regex, result[0].suggestions.join(', ')));
         //               }
         //           }
         //       ]
@@ -101,7 +101,7 @@ module.exports = {
                 customFile: 'string'
             }
         ],
-        type: 'suggestion'
+        type: 'suggestions'
     },
     create: function (context) {
         const customConfig = getCustomRuleConfig(context);

--- a/tests/lib/rules/use-inclusive-words.test.js
+++ b/tests/lib/rules/use-inclusive-words.test.js
@@ -6,8 +6,8 @@ const customConfig = {
     words: [
         {
             word: 'guys',
-            suggestion: 'people',
-            explanation: "Instead of '{{word}}', you can use '{{suggestion}}'."
+            suggestions: ['people'],
+            explanation: "Instead of '{{word}}', you can use '{{suggestions}}'."
         }
     ],
     allowedTerms: [


### PR DESCRIPTION
## Proposed changes
This change attempts to enhance the plugin to have **more than one** inclusive suggestion as alternative to the words configured. 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Related Issues
- Fixes #17 

## PR Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/muenzpraeger/eslint-plugin-inclusive-language/blob/primary/CONTRIBUTION.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my feature works
- [x] I have updated necessary documentation
