### PR TITLE
[performance] don't instantiate a new Regex on every word & visitor

### DIFF
--- a/lib/rules/use-inclusive-words.js
+++ b/lib/rules/use-inclusive-words.js
@@ -22,6 +22,8 @@ let ruleConfig = JSON.parse(
     'utf8'
 );
 
+let wordDeclarationRegexMap = new Map();
+
 /**
  * Remove allowed terms from the list of words, checking
  * for partial or complete matches based on each allowed
@@ -72,10 +74,9 @@ function validateIfInclusive(context, node, value) {
     let regex;
 
     const result = ruleConfig.words.find((wordDeclaration) => {
-        // match whole words and partial words, at the end and beginning of sentences
-        regex = new RegExp(`[\\w-_/]*(${wordDeclaration.word})[\\w-_/]*`, 'ig');
-        const matches = value.match(regex);
-        if (matches) return excludeAllowedTerms(matches).length;
+        regex = wordDeclarationRegexMap.get(wordDeclaration.word);
+        const didMatch = regex.test(value);
+        if (didMatch) return excludeAllowedTerms(value.match(regex)).length;
     });
 
     if (!result) return;
@@ -135,6 +136,16 @@ module.exports = {
         if (customConfig) {
             ruleConfig = mergeRuleConfigs(ruleConfig, customConfig);
         }
+
+        ruleConfig.words.forEach(({ word }) => {
+            if (!wordDeclarationRegexMap.has(word)) {
+                wordDeclarationRegexMap.set(
+                    word,
+                    // match whole words and partial words, at the end and beginning of sentences
+                    new RegExp(`[\\w-_/]*(${word})[\\w-_/]*`, 'ig')
+                );
+            }
+        });
 
         return {
             Literal(node) {


### PR DESCRIPTION
@muenzpraeger I know this isn't the PR you asked for, but we've been trying this rule out at Airbnb and the performance is too slow for us to adopt it at the moment.  After some investigation we noticed that most of the time is spent in the `find` loop in `validateIfInclusive`. Specifically, creating the regex (which this PR tries to address) & doing a regex test/match on every word.

I have some numbers to show you the impact of this change. Note that both tables are the result of running eslint on a project with around ~220 files (our monorepo is ~80,000 lint-able files). And we're grabbing the top 10 slowest rules in the tables below.

Primary branch (without this change):
```
Rule                                     | Time (ms) | Relative
:----------------------------------------|----------:|--------:
inclusive-language/use-inclusive-words   |  5099.442 |    58.7%
prettier/prettier                        |  1638.094 |    18.9%
import/no-named-as-default               |   575.031 |     6.6%
import/no-extraneous-dependencies        |   242.964 |     2.8%
react/destructuring-assignment           |   100.284 |     1.2%
react/jsx-no-bind                        |    68.038 |     0.8%
react/no-deprecated                      |    64.522 |     0.7%
rulesdir/no-hyperloop-restricted-imports |    58.105 |     0.7%
react/void-dom-elements-no-children      |    46.405 |     0.5%
import/no-named-as-default-member        |    42.151 |     0.5%
✨  Done in 17.45s.
```
With this change to stop re-instantiating Regex:
```
Rule                                     | Time (ms) | Relative
:----------------------------------------|----------:|--------:
inclusive-language/use-inclusive-words   |  2242.047 |    36.9%
prettier/prettier                        |  1766.999 |    29.1%
import/no-named-as-default               |   608.474 |    10.0%
import/no-extraneous-dependencies        |   299.712 |     4.9%
react/destructuring-assignment           |   103.340 |     1.7%
react/jsx-no-bind                        |    67.114 |     1.1%
rulesdir/no-hyperloop-restricted-imports |    61.666 |     1.0%
react/no-deprecated                      |    59.973 |     1.0%
react/void-dom-elements-no-children      |    49.458 |     0.8%
import/no-named-as-default-member        |    46.883 |     0.8%
✨  Done in 15.63s.
```
Performance improves quite dramatically, but it's still not ideal or fast enough for us to adopt it. It would be great if we didn't have to duplicate the `value.test` for every word on every visitor but I'm not sure what's the best way to achieve that without restructuring the core logic. However this change should help a bit.

Note that none of the functionality of the rule changes in this PR. The change I did make was to stop instantiating a new Regex class instance on every iteration on ever node visit. So I'm relying on the existing tests to validate this.

cc. @lencioni