### PR TITLE
chore: improve format and lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+yarn.lock

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    extends: ['eslint:recommended'],
+    extends: ['eslint:recommended', 'plugin:json/recommended'],
     parserOptions: {
         ecmaVersion: 2018,
         sourceType: 'module'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -33,7 +33,7 @@ jobs:
 
             # Prettier formatting
             - name: 'Code formatting verification with Prettier'
-              run: yarn prettier:verify
+              run: yarn format:verify
 
             # ESlint
             - name: 'ESlint verification'

--- a/.github/workflows/build-primary.yml
+++ b/.github/workflows/build-primary.yml
@@ -34,7 +34,7 @@ jobs:
 
             # Prettier formatting
             - name: 'Code formatting verification with Prettier'
-              run: yarn prettier:verify
+              run: yarn format:verify
 
             # ESlint
             - name: 'ESlint verification'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "devDependencies": {
         "eslint": "^7.19.0",
+        "eslint-plugin-json": "^2.1.2",
         "husky": "^4.3.8",
         "jest": "^26.6.3",
         "lint-staged": "^10.5.3",
@@ -20,9 +21,9 @@
         "lib/"
     ],
     "scripts": {
-        "lint": "eslint **/lib/**/*.js",
-        "prettier": "prettier --write '**/*.{js,json,md,yml}'",
-        "prettier:verify": "prettier --list-different '**/*.{js,json,md,yml}'",
+        "lint": "eslint .",
+        "format": "prettier --write .",
+        "format:verify": "prettier --list-different .",
         "test:unit": "jest",
         "test:unit:coverage": "jest --coverage",
         "test:unit:watch": "jest --watch"
@@ -37,11 +38,9 @@
         }
     },
     "lint-staged": {
-        "**/*.{js,json,md,yml}": [
-            "prettier --write"
-        ],
-        "**/lib/**/*.js": [
-            "eslint"
+        "*": [
+            "yarn lint",
+            "yarn format:verify"
         ]
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,6 +1351,14 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-json@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-json/-/eslint-plugin-json-2.1.2.tgz#5bc1c221984583c0c5ff21c488386e8263a6bbb7"
+  integrity sha512-isM/fsUxS4wN1+nLsWoV5T4gLgBQnsql3nMTr8u+cEls1bL8rRQO5CP5GtxJxaOfbcKqnz401styw+H/P+e78Q==
+  dependencies:
+    lodash "^4.17.19"
+    vscode-json-languageservice "^3.7.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2690,6 +2698,11 @@ json5@^2.1.2:
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   dependencies:
     minimist "^1.2.5"
+
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -4107,6 +4120,37 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vscode-json-languageservice@^3.7.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.11.0.tgz#ad574b36c4346bd7830f1d34b5a5213d3af8d232"
+  integrity sha512-QxI+qV97uD7HHOCjh3MrM1TfbdwmTXrMckri5Tus1/FQiG3baDZb2C9Y0y8QThs7PwHYBIQXcAc59ZveCRZKPA==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "3.16.0-next.2"
+    vscode-nls "^5.0.0"
+    vscode-uri "^2.1.2"
+
+vscode-languageserver-textdocument@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
+  integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
+
+vscode-languageserver-types@3.16.0-next.2:
+  version "3.16.0-next.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz#940bd15c992295a65eae8ab6b8568a1e8daa3083"
+  integrity sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==
+
+vscode-nls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
+  integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
+
+vscode-uri@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
+  integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
closes #37 

Changes:

- Renamed `package.json` scrip `prettier` to `format` to prevent naming conflicts when executing `yarn prettier` manually
- Use `lint-staged` to check/lint every file in the repo
- Change scripts to check/lint/format every file in the repo
- Add `eslint-plugin-json` so `package.json` can be checked by `eslint`