### PR TITLE
feat: improve inclusive-words

### DIFF
--- a/lib/config/inclusive-words.json
+++ b/lib/config/inclusive-words.json
@@ -2,24 +2,29 @@
     "allowedTerms": [],
     "words": [
         {
-            "explanation": "To convey the same idea, consider '{{suggestion}}' instead of '{{word}}'.",
+            "word": "blacklist",
             "suggestions": ["blocklist", "denylist"],
-            "word": "blacklist"
+            "explanation": "To convey the same idea, consider '{{suggestion}}' instead of '{{word}}'."
         },
         {
-            "explanation": "To convey the same idea, consider '{{suggestion}}' instead of '{{word}}'.",
+            "word": "whitelist",
             "suggestions": ["allowlist", "passlist"],
-            "word": "whitelist"
+            "explanation": "To convey the same idea, consider '{{suggestion}}' instead of '{{word}}'."
         },
         {
-            "explanation": "Instead of '{{word}}', you can use '{{suggestion}}'.",
+            "word": "guys",
+            "suggestions": ["folks", "people"],
+            "explanation": "Instead of '{{word}}', you may use '{{suggestion}}'."
+        },
+        {
+            "word": "master",
             "suggestions": ["primary", "main"],
-            "word": "master"
+            "explanation": "Instead of '{{word}}', you can use '{{suggestion}}'."
         },
         {
-            "explanation": "Instead of '{{word}}', you really should consider an alternative like '{{suggestion}}'.",
+            "word": "slave",
             "suggestions": ["secondary", "replica"],
-            "word": "slave"
+            "explanation": "Instead of '{{word}}', you really should consider an alternative like '{{suggestion}}'."
         }
     ]
 }

--- a/lib/config/inclusive-words.json
+++ b/lib/config/inclusive-words.json
@@ -1,5 +1,10 @@
 {
-    "allowedTerms": [],
+    "allowedTerms": [
+        {
+            "term": "/master",
+            "allowPartialMatches": true
+        }
+    ],
     "words": [
         {
             "word": "blacklist",


### PR DESCRIPTION
closes #38 

Changes:

- reorder json keys for better human usage
- add terms guys and suggest the usage of folks or people
- add allowed term `/master` so URLs like from GitHub can include `/master` as long as GitHub allows it